### PR TITLE
Add #find_action for search blueprint actions by url and method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+before_install:
+  - gem uninstall bundler
+  - gem install bundler --version '1.7.1'
 rvm:
   - 2.1.1
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # RedSnow needs to download its git submodules before compiling
-gem 'redsnow', '>= 0.1.3', github: 'apiaryio/redsnow', submodules: true
+gem 'redsnow', github: 'apiaryio/redsnow', submodules: true
 gem 'codeclimate-test-reporter', group: :test, require: nil
 
 gemspec

--- a/lib/vigia/adapters/blueprint.rb
+++ b/lib/vigia/adapters/blueprint.rb
@@ -92,7 +92,21 @@ module Vigia
         end
       end
 
+      def find_action(url, method)
+        resources_by_url(url).map(&:actions).flatten.select do|action|
+          action && (method.nil? || action.method.downcase == method.to_s.downcase)
+        end.first
+      end
+
       private
+
+
+      def resources_by_url(url)
+       apib_resources.select do |resource|
+          path = URI.parse(url).path
+          Vigia::Url.template_defines_url?(resource.uri_template, path)
+        end
+      end
 
       def locate_in_sourcemap(key, object)
         node_index  = apib_structure[key].index(object)
@@ -130,6 +144,10 @@ module Vigia
 
       def apib_structure
         @apib_structure ||= build_structure(apib)
+      end
+
+      def apib_resources
+        apib.resource_groups.map(&:resources).flatten
       end
 
       def build_structure(start_point)

--- a/spec/support/shared_examples/redsnow_doubles.rb
+++ b/spec/support/shared_examples/redsnow_doubles.rb
@@ -3,11 +3,11 @@ shared_examples "redsnow doubles" do
   let(:resource) do
     instance_double(
       RedSnow::Resource,
-      name: resource_name,
-      description: resource_description,
-      parameters: resource_parameters,
+      name:         resource_name,
+      description:  resource_description,
+      parameters:   resource_parameters,
       uri_template: resource_uri_template,
-      model: resource_model
+      model:        resource_model
     )
   end
 


### PR DESCRIPTION
Provides a way to ask the Blueprint adaptor for a specific action by its url and method. 